### PR TITLE
Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * USB flash drive loaded with 64-bit [Xubuntu 20.04](https://xubuntu.org/release/20-04/)
 * Cell phone with [Google Lens app](https://play.google.com/store/apps/details?id=com.google.ar.lens&hl=en_US&gl=US)
 
-## Prepare Web3 Environment
+## Prepare Python and segno QR Code Programs
 
 Boot computer with USB Flash drive loaded with Xubuntu 20.04. Machine should be connected to the Internet for the beginning steps:
 
@@ -28,3 +28,25 @@ pip3 install web3  # 5.16.0 at time of writing
 python3
 ```
 You should now be in a Python 3.8 interactive session.
+
+## Load Web3 and Pangolin Claim Contract
+
+The following will be a pain to type in, but its worth it to do manually for good security.
+
+```python3
+from web3 import Web3, HTTPProvider
+claim_abi = """\
+[
+  {
+	"inputs": [],
+	"name": "claim",
+	"outputs": [],
+	"stateMutability": "nonpayable",
+	"type": "function"
+  }
+]
+"""
+provider = HTTPProvider("https://api.avax.network/ext/bc/C/rpc")
+w3 = Web3(provider)
+pangolin = w3.eth.contract(address="0x0C58C2041da4CfCcF5818Bbe3b66DBC23B3902d9", abi=claim_abi)
+```

--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@
 * Computer that can be booted by USB flash drive
 * USB flash drive loaded with 64-bit [Xubuntu 20.04](https://xubuntu.org/release/20-04/)
 * Cell phone with [Google Lens app](https://play.google.com/store/apps/details?id=com.google.ar.lens&hl=en_US&gl=US)
+
+## Prepare Web3 Environment
+
+Boot computer with USB Flash drive loaded with Xubuntu 20.04. Machine should be connected to the Internet for the beginning steps:
+
+```bash
+cd  # start in home directory
+sudo apt update
+sudo apt install -y build-essential git python3-dev python3-venv
+python3 -m venv venv
+source venv/bin/activate
+git clone https://github.com/heuer/segno.git  # segno==1.3.2.dev0 at time of writing
+cd segno  # return to home directory
+python3 setup.py install
+cd
+pip3 install web3  # 5.16.0 at time of writing
+python3
+```
+You should now be in a Python 3.8 interactive session.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ w3.eth.sendRawTransaction(signed_rawTransaction)
 
 The resulting `HexBytes('Ox...')` indicates the transaction has been submitted to the Avalanche C-chain. You can look for it at (Avascan)[https://avascan.info/].
 
-# Next Steps
+# Next Steps (COMING SOON TO THIS TUTORIAL)
 
-* Show how to move PNG token from Trezor wallet to another more useable wallet.
-* How to withdraw any existing AVAX in your Trezor wallet.
+* Show how to move PNG and other ERC20 tokens from a Trezor wallet to a non-Trezor wallet.
+* How to withdraw any existing AVAX stored in your Trezor wallet.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ os.system(cmd)
 ```
 
 The QR code should appear directly in the terminal. Use the Xubuntu terminal `View: Zoom Out` menu option as many times as needed. Use Google Lens to get its value onto your cell phone's clipboard. Then email it to yourself. Since its a signed transaction, its safe to do. Keep in mind this portion of data will be published to a public blockchain. At this point, you can turn off your temporary Xubuntu machine. Its no longer needed.
-```
 
-# Time to Claim Your Destiny (ONLINE)
+## Time to Claim Your Destiny (ONLINE)
 
 At this point, you can either reboot your computer using the Xubuntu flash drive, or use another normal   computer with web3 and python3 installed. In Python:
 
@@ -114,7 +113,7 @@ w3.eth.sendRawTransaction(signed_rawTransaction)
 
 The resulting `HexBytes('Ox...')` indicates the transaction has been submitted to the Avalanche C-chain. You can look for it at (Avascan)[https://avascan.info/].
 
-# Next Steps (COMING SOON TO THIS TUTORIAL)
+## Next Steps (COMING SOON TO THIS TUTORIAL)
 
 * Show how to move PNG and other ERC20 tokens from a Trezor wallet to a non-Trezor wallet.
 * How to withdraw any existing AVAX stored in your Trezor wallet.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 ## Introduction
 
 [Pangolin](https://pangolin.exchange/) is a new DEX which debuted on the [Avalanche](https://www.avalabs.org/) mainnet on [February 9, 2021](https://twitter.com/pangolindex/status/1359245703592218627). It has offered an airdrop of its PNG token to anyone holding UNI or SUSHI in an Ethereum wallet as of Dec 7, 2020. The [claim process](https://pangolin.exchange/tutorials/claim-png) relies primarily on using MetaMask, which unfortunately doesn't work for Trezor wallets on the Avalanche side. The deadline to claim this airdrop is "one month of Pangolin’s launch" (unclear if this means 30 or 31 days). Its unlikely Trezor will be patched to worked with MetaMask before this deadline. The following tutorial shows how to load a Trezor seed phrase into an offline temporary computer and through a reasonably safe method transfer a signed transaction back to an online computer and publish it to the Avalanche network to claim an airdrop.
+
+## Requirements
+
+* Computer that can be booted by USB flash drive
+* USB flash drive loaded with 64-bit [Xubuntu 20.04](https://xubuntu.org/release/20-04/)
+* Cell phone with [Google Lens app](https://play.google.com/store/apps/details?id=com.google.ar.lens&hl=en_US&gl=US)

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Account.enable_unaudited_hdwallet_features()
 If your Trezor has a seed phrase + passphare, do this to load your account:
 
 ```python3
-from_acct = Account.from_mnemonic("put your seed phrase", "your passphrase")
+from_acct = Account.from_mnemonic("put your lowecase space separated seed phrase", "your passphrase")
 ```
 
 Otherwise, if your Trezor uses only a seed phrase:
 
 ```python3
-from_acct = Account.from_mnemonic("put your seed phrase")
+from_acct = Account.from_mnemonic("put your lowercase space separated seed phrase")
 ```
 
 If Python complains you don't have a valid seed phrase, make sure you made no typos in the words. See the [official English dictionary for seed phrases (BIP39)](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 ## Introduction
 
-[Pangolin](https://pangolin.exchange/) is a new DEX which debuted on the [Avalanche](https://www.avalabs.org/) mainnet on [February 9, 2021](https://twitter.com/pangolindex/status/1359245703592218627). It has offered an airdrop of its PNG token to anyone holding UNI or SUSHI in an Ethereum wallet as of Dec 7, 2020. The [claim process](https://pangolin.exchange/tutorials/claim-png) relies primarily on using MetaMask, which unfortunately doesn't work for Trezor wallets on the Avalanche side. The deadline to claim this airdrop is "one month of Pangolin’s launch" (unclear if this means 30 or 31 days). Its unlikely Trezor will be patched to worked with MetaMask before this deadline. The following tutorial shows how to load a Trezor seed phrase into an offline temporary computer and through a reasonably safe method transfer a signed transaction back to an online computer and publish it to the Avalanche network to claim an airdrop.
+[Pangolin](https://pangolin.exchange/) is a new DEX which debuted on the [Avalanche](https://www.avalabs.org/) mainnet on [February 9, 2021](https://twitter.com/pangolindex/status/1359245703592218627). It has offered an airdrop of its PNG token to anyone holding UNI or SUSHI in an Ethereum wallet as of Dec 7, 2020. The [claim process](https://pangolin.exchange/tutorials/claim-png) relies primarily on using MetaMask, which unfortunately doesn't work for Trezor wallets on the Avalanche side. The deadline to claim this airdrop is "one month of Pangolin’s launch" (unclear if this means 30 or 31 days). Its unlikely Trezor will be patched to worked with MetaMask before this deadline. The following tutorial shows how to load a Trezor seed phrase into an offline temporary computer and through a reasonably safe method transfer a signed transaction back to an online computer and publish it to the Avalanche network to claim an airdrop. Given the rapidly approaching deadline for the airdrop, the initial focus here is to claim the PNG. Further steps will be published in the next few days to show how to move C-AVAX and ERC20 tokens out of a Trezor wallet.
 
 ## Requirements
 
 * Computer that can be booted by USB flash drive
 * USB flash drive loaded with 64-bit [Xubuntu 20.04](https://xubuntu.org/release/20-04/)
 * Cell phone with [Google Lens app](https://play.google.com/store/apps/details?id=com.google.ar.lens&hl=en_US&gl=US)
-* Send at least 0.5 C-AVAX to your Trezor C-chain address (same address as your Trezor Ethereum address) to use for gas costs. Note: upcoming edits to this tutorial will show you how to withdraw remaining C-AVAX funds back to a more useful wallet.
+* Before starting the tutorial, send at least 0.5 C-AVAX to your Trezor C-chain address (same address as your Trezor Ethereum address) to use for gas costs. Note: upcoming edits to this tutorial will show you how to withdraw remaining C-AVAX funds back to a non-Trezor wallet.
+* Before starting the tutorial, use a non-Trezor account on Pangolin to buy 1 UNI and/or 1 SUSHI (depending on which tokens you held on Dec 7, 2020 on Ethereum) and transfer it to your Trezor C-AVAX address. Note: upcoming edits will show you how to withdraw ERC20 tokens to your non-Trezor wallet.
 
 ## Prepare Python and segno QR Code Programs (ONLINE)
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 * Computer that can be booted by USB flash drive
 * USB flash drive loaded with 64-bit [Xubuntu 20.04](https://xubuntu.org/release/20-04/)
 * Cell phone with [Google Lens app](https://play.google.com/store/apps/details?id=com.google.ar.lens&hl=en_US&gl=US)
+* Send at least 0.5 C-AVAX to your Trezor C-chain address (same address as your Trezor Ethereum address) to use for gas costs. Note: upcoming edits to this tutorial will show you how to withdraw remaining C-AVAX funds back to a more useful wallet.
 
-## Prepare Python and segno QR Code Programs
+## Prepare Python and segno QR Code Programs (ONLINE)
 
 Boot computer with USB Flash drive loaded with Xubuntu 20.04. Machine should be connected to the Internet for the beginning steps:
 
@@ -27,11 +28,10 @@ cd
 pip3 install web3  # 5.16.0 at time of writing
 python3
 ```
-You should now be in a Python 3.8 interactive session.
 
-## Load Web3 and Pangolin Claim Contract
+## Load Web3 and Pangolin Claim Contract (ONLINE)
 
-The following will be a pain to type in, but its worth it to do manually for good security.
+You should now be in a Python 3.8 interactive session. The following will be a pain to type in, but its worth it to do manually for good security. The following must be done while conntected to the Internet.
 
 ```python3
 from web3 import Web3, HTTPProvider
@@ -49,4 +49,71 @@ claim_abi = """\
 provider = HTTPProvider("https://api.avax.network/ext/bc/C/rpc")
 w3 = Web3(provider)
 pangolin = w3.eth.contract(address="0x0C58C2041da4CfCcF5818Bbe3b66DBC23B3902d9", abi=claim_abi)
+tx = {}
+tx["gas"] = 100000
+tx["gasPrice"] = Web3.toWei(470, "Gwei")  # the default C-chain gas price at time of writing
+tx["nonce"] = 0   # assumes this is your first tx ever for trezor avax side
+tx["chainId"] = 43114  # avax mainnet
+claim_tx = pangolin.functions.claim().buildTransaction(tx)
 ```
+
+## Load Your Trezor Account (OFFLINE)
+
+Keep the python interactive session open. However, the following must be done with your machine offline. Are you offline now? Good. Proceed with no one looking over your shoulder, or web cams watching:
+
+```python3
+from web3.eth import Account
+Account.enable_unaudited_hdwallet_features()
+```
+
+If your Trezor has a seed phrase + passphare, do this to load your account:
+
+```python3
+from_acct = Account.from_mnemonic("put your seed phrase", "your passphrase")
+```
+
+Otherwise, if your Trezor uses only a seed phrase:
+
+```python3
+from_acct = Account.from_mnemonic("put your seed phrase")
+```
+
+If Python complains you don't have a valid seed phrase, make sure you made no typos in the words. See the [official English dictionary for seed phrases (BIP39)](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt).
+
+Confirm your address is what you expect it to be. If its wrong. Do not proceed.
+
+```python3
+print(from_acct.address)  # make sure it matches what you expect
+```
+
+## Sign the Claim Transaction (OFFLINE)
+
+Hit `Enter` a zillion times to clear the screen of your seed phrase line and/or passphrase information. Next, the following will generate a QR code version of your signed transaction:
+
+```python3
+cmd = f"segno {from_acct.sign_transaction(claim_tx).rawTransaction.hex()}"
+import os
+os.system(cmd)
+```
+
+The QR code should appear directly in the terminal. Use the Xubuntu terminal `View: Zoom Out` menu option as many times as needed. Use Google Lens to get its value onto your cell phone's clipboard. Then email it to yourself. Since its a signed transaction, its safe to do. Keep in mind this portion of data will be published to a public blockchain. At this point, you can turn off your temporary Xubuntu machine. Its no longer needed.
+```
+
+# Time to Claim Your Destiny (ONLINE)
+
+At this point, you can either reboot your computer using the Xubuntu flash drive, or use another normal   computer with web3 and python3 installed. In Python:
+
+```python3
+from web3 import Web3, HTTPProvider
+provider = HTTPProvider("https://api.avax.network/ext/bc/C/rpc")
+w3 = Web3(provider)
+signed_rawTransaction = "my tranaction hex code"
+w3.eth.sendRawTransaction(signed_rawTransaction)
+```
+
+The resulting `HexBytes('Ox...')` indicates the transaction has been submitted to the Avalanche C-chain. You can look for it at (Avascan)[https://avascan.info/].
+
+# Next Steps
+
+* Show how to move PNG token from Trezor wallet to another more useable wallet.
+* How to withdraw any existing AVAX in your Trezor wallet.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # png-airdrop-offline-signature
 
-Temp readme
+## Introduction
+
+[Pangolin](https://pangolin.exchange/) is a new DEX which debuted on the [Avalanche](https://www.avalabs.org/) mainnet on [February 9, 2021](https://twitter.com/pangolindex/status/1359245703592218627). It has offered an airdrop of its PNG token to anyone holding UNI or SUSHI in an Ethereum wallet as of Dec 7, 2020. The [claim process](https://pangolin.exchange/tutorials/claim-png) relies primarily on using MetaMask, which unfortunately doesn't work for Trezor wallets on the Avalanche side. The deadline to claim this airdrop is "one month of Pangolin’s launch" (unclear if this means 30 or 31 days). Its unlikely Trezor will be patched to worked with MetaMask before this deadline. The following tutorial shows how to load a Trezor seed phrase into an offline temporary computer and through a reasonably safe method transfer a signed transaction back to an online computer and publish it to the Avalanche network to claim an airdrop.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ from_acct = Account.from_mnemonic("lowercase space separated seed phrase")
 
 If Python complains you don't have a valid seed phrase, make sure you made no typos in the words. See the [official English dictionary for seed phrases (BIP39)](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt).
 
-Confirm your address is what you expect it to be. If its wrong. Do not proceed.
+Confirm your address is what you expect it to be. If its wrong, do not proceed.
 
 ```python3
 print(from_acct.address)  # make sure it matches what you expect

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Account.enable_unaudited_hdwallet_features()
 If your Trezor has a seed phrase + passphare, do this to load your account:
 
 ```python3
-from_acct = Account.from_mnemonic("put your lowecase space separated seed phrase", "your passphrase")
+from_acct = Account.from_mnemonic("lowecaser space separated seed phrase", "your passphrase")
 ```
 
 Otherwise, if your Trezor uses only a seed phrase:
 
 ```python3
-from_acct = Account.from_mnemonic("put your lowercase space separated seed phrase")
+from_acct = Account.from_mnemonic("lowercase space separated seed phrase")
 ```
 
 If Python complains you don't have a valid seed phrase, make sure you made no typos in the words. See the [official English dictionary for seed phrases (BIP39)](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt).


### PR DESCRIPTION
This tutorial lets people claim their PNG as soon as possible before the month-long deadline expires. Future edits will show how to move PNG, UNI, and C-AVAX out of the Trezor account.